### PR TITLE
FIX #39

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ set(UTILS_SRC_FILES
         utils/typeHelper.cpp
         utils/printDebugInfo.cpp
         utils/parseConfig.h
-        )
+        utils/filename.h)
 
 #---------------
 #   FRONT-END

--- a/cli/Config.h
+++ b/cli/Config.h
@@ -17,6 +17,7 @@ typedef struct Config {
 
     Target target = Target::X86_64;
     std::string fileToCompile{};
+    std::string fileWithPath{};
 
 } Config;
 

--- a/cli/Runner.cpp
+++ b/cli/Runner.cpp
@@ -16,7 +16,7 @@ using std::endl;
 int Runner::run(Config *conf) {
 
     std::fstream inputFile;
-    inputFile.open(conf->fileToCompile, std::fstream::in);
+    inputFile.open(conf->fileWithPath, std::fstream::in);
 
     std::cout << "Opening file: " << conf->fileToCompile << std::endl;
 

--- a/utils/filename.h
+++ b/utils/filename.h
@@ -1,0 +1,35 @@
+#ifndef MAPLECOMPILER_FILENAME_H
+#define MAPLECOMPILER_FILENAME_H
+
+#include <string>
+#include <vector>
+#include <sstream>
+#include <iterator>
+
+std::vector<std::string> split(const std::string &s, char delimiter) {
+    std::vector<std::string> tokens;
+    std::string token;
+    std::istringstream tokenStream(s);
+    while (std::getline(tokenStream, token, delimiter)) {
+        tokens.push_back(token);
+    }
+    return tokens;
+}
+
+std::string filename(const std::string &filename) {
+    std::vector<std::string> tokens = split(filename, '/');
+
+    std::string filenameWithoutPath = tokens[tokens.size() - 1];
+
+    tokens = split(filenameWithoutPath, '.');
+
+    std::string cleanFilename;
+    for (int i = 0; i < tokens.size() - 1; i++) {
+        cleanFilename += tokens[i];
+    }
+
+    return cleanFilename;
+}
+
+
+#endif //MAPLECOMPILER_FILENAME_H

--- a/utils/parseConfig.h
+++ b/utils/parseConfig.h
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <unistd.h>
 #include "str2int.h"
+#include "filename.h"
 
 Config *parseConfig(int argc, char *const *argv) {
     const static auto usage = "Usage: ./mapleCompiler [-a] [-o] [-c] [-t <x64|msp430|java>] <file.c>";
@@ -52,7 +53,8 @@ Config *parseConfig(int argc, char *const *argv) {
                 }
                 break;
             case '\1':
-                config->fileToCompile = std::string(optarg);
+                config->fileToCompile = filename(std::string(optarg));
+                config->fileWithPath = std::string(optarg);
                 break;
             case '?':
                 std::cerr << "Unknown option: '" << char(optopt) << "'!" << std::endl;


### PR DESCRIPTION
New utils file to split filename and get it without path and extension. New attribut in Config.h (fileWithPath).

Fix #39 